### PR TITLE
Fixed navigation bar issue

### DIFF
--- a/image-scroll-swift/ViewController.swift
+++ b/image-scroll-swift/ViewController.swift
@@ -51,7 +51,7 @@ class ViewController: UIViewController, UIScrollViewDelegate {
       let imageHeight = image.size.height
 
       let viewWidth = view.bounds.size.width
-      let viewHeight = view.bounds.size.height
+      let viewHeight = view.bounds.size.height - scrollView.contentInset.top
 
       // center image if it is smaller than screen
       var hPadding = (viewWidth - scrollView.zoomScale * imageWidth) / 2


### PR DESCRIPTION
Subtracted the `scrollView.contentInset.top` value from the `viewHeight`, so that when this view is presented with a navigation bar, it doesn't calculate incorrect vertical margins.
